### PR TITLE
Fix: Sidebar and Editor should scroll independently

### DIFF
--- a/CSS/index.css
+++ b/CSS/index.css
@@ -1291,6 +1291,7 @@ input:checked+.toggle-slider:before {
   transition: grid-template-columns 0s;
   flex: 1;
   min-height: 0;
+  height: 0;
 }
 
 /* Hidden sidebar state (Mini Sidebar) */
@@ -2359,7 +2360,7 @@ body[data-theme="corporate-gray"] .editor[data-theme="minimal-white"] {
   box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
-  flex: 1;
+  height: 100%;
   min-height: 0;
   min-width: 0;
   overflow: hidden;
@@ -3282,13 +3283,17 @@ textarea:hover::-webkit-scrollbar-thumb {
 
 .editor-content {
   flex: 1 1 0%;
+  width: 100%;
   outline: none;
   font-family: 'Inter', sans-serif;
   line-height: 1.7;
   font-size: 15px;
   color: var(--text);
   overflow-y: auto;
+  overflow-x: hidden;
   min-height: 0;
+  word-break: break-word;
+  overflow-wrap: break-word;
 
   /* Soft, non-harsh border */
   border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);


### PR DESCRIPTION
## 📝 Description
Refactored the layout to ensure the sidebar and main editor scroll independently.

Previously, the sidebar height was tied to viewport calculations and sticky positioning, which caused layout instability and page-level scrolling.

This update removes viewport-dependent height logic and enables proper internal scrolling behavior.

## 🔗 Related Issue
Closes #70

## 🧪 Type of Change
- [x] Enhancement

## ✅ Checklist
- [x] Code follows project structure
- [x] Tested locally
- [x] No unnecessary files added

## 📸 Screenshots

<img width="1534" height="943" alt="image" src="https://github.com/user-attachments/assets/4b125c94-0557-4bc9-b59a-cb2cb8ae6791" />


Before:
- Sidebar moved with page scroll
- Global scrollbar visible

After:
- Sidebar remains fixed
- Editor scrolls independently
- No global page scroll

---

Happy to make any adjustments if needed.